### PR TITLE
Fix typo in swerv.config causing wrong unsets to be printed

### DIFF
--- a/configs/swerv.config
+++ b/configs/swerv.config
@@ -1979,7 +1979,7 @@ sub map_set_unset {
         }
     }
     if (scalar(@unsets)) {
-        print "$self: Unset(s) requested : @sets\n";
+        print "$self: Unset(s) requested : @unsets\n";
         foreach (@unsets) {
             $unsets{$_} = 1;
         }


### PR DESCRIPTION
This is only for the summary of options. No functional change